### PR TITLE
Fixed unresolved merge conflict

### DIFF
--- a/timescaledb.rb
+++ b/timescaledb.rb
@@ -1,15 +1,9 @@
 class Timescaledb < Formula
   desc "An open-source time-series database optimized for fast ingest and complex queries. Fully compatible with PostgreSQL."
   homepage "https://www.timescaledb.com"
-<<<<<<< Updated upstream
-  url "https://timescalereleases.blob.core.windows.net/homebrew/timescaledb-0.11.0.tar.gz"
-  version "0.11.0"
-  sha256 "d7e14283b40e169fe3f6885b111773ba24764d848d6d9f6af122c17acdacbc67"
-=======
   url "https://timescalereleases.blob.core.windows.net/homebrew/timescaledb-0.12.0.tar.gz"
   version "0.12.0"
   sha256 "14914c13430417671cef832bc213e6389585d59e507c1c7956d0bcb512eb55b1"
->>>>>>> Stashed changes
 
   depends_on "cmake" => :build
   depends_on "postgresql" => :build


### PR DESCRIPTION
After `brew upgrade` did not update my Homebrew installation of TimescaleDB to 0.12, I tried to re-pin the formula and saw the following error message.

It looks like a git merge failed and the conflict didn't get resolved before you pushed the updated formula to Homebrew.

```
Error: timescaledb: /usr/local/Homebrew/Library/Taps/timescale/homebrew-tap/timescaledb.rb:4: syntax error, unexpected <<, expecting keyword_end
<<<<<<< Updated upstream
  ^
/usr/local/Homebrew/Library/Taps/timescale/homebrew-tap/timescaledb.rb:8: syntax error, unexpected ===, expecting keyword_end
=======
   ^
/usr/local/Homebrew/Library/Taps/timescale/homebrew-tap/timescaledb.rb:12: syntax error, unexpected >>, expecting keyword_end
>>>>>>> Stashed changes
  ^
```