### PR TITLE
Create timescaledb-tools package

### DIFF
--- a/timescaledb-tools.rb
+++ b/timescaledb-tools.rb
@@ -1,0 +1,17 @@
+class TimescaledbTools < Formula
+  desc "Client tools for working with TimescaleDB"
+  homepage "https://www.timescaledb.com"
+  url "https://timescalereleases.blob.core.windows.net/homebrew/timescaledb-tools-0.2.0.tar.gz"
+  version "0.2.0"
+  sha256 "5aa89289279b1d5f1a5c47d22d1aea8358a075cc2be3d89593465c0e083ce248"
+
+  def install
+    bin.install "timescaledb-tune"
+    bin.install "timescaledb-parallel-copy"
+    end
+
+  test do
+    system "timescaledb-tune", "--version"
+    system "timescaledb-parallel-copy", "--version"
+  end
+end

--- a/timescaledb.rb
+++ b/timescaledb.rb
@@ -2,12 +2,13 @@ class Timescaledb < Formula
   desc "An open-source time-series database optimized for fast ingest and complex queries. Fully compatible with PostgreSQL."
   homepage "https://www.timescaledb.com"
   url "https://timescalereleases.blob.core.windows.net/homebrew/timescaledb-1.1.1.tar.gz"
-  version "1.1.1"
+  version "1.1.1-1"
   sha256 "6fc7c43b436a1b7f100b22f3ca1691c99b9a912ff9e8f95269401fe192811d19"
 
   depends_on "cmake" => :build
   depends_on "postgresql" => :build
   depends_on "openssl" => :build
+  depends_on "timescaledb-tools" => :recommended
 
   def install
     system "./bootstrap -DPROJECT_INSTALL_METHOD=\"brew\""
@@ -33,13 +34,17 @@ class Timescaledb < Formula
 
   def caveats
     pgvar = `find /usr/local/var/postgres* -name "postgresql.conf" | head -n 1`
-    s = "Make sure to update #{pgvar.strip} to include the extension:\n\n"
+    s = "RECOMMENDED: Run 'timescaledb-tune' to update your config settings for TimescaleDB.\n\n"
+    s += "  timescaledb-tune --quiet --yes\n\n"
+
+    s += "IF NOT, you'll need to make sure to update #{pgvar.strip}\nto include the extension:\n\n"
     s += "  shared_preload_libraries = 'timescaledb'\n\n"
+
     s += "To finish the installation, you will need to run:\n\n"
-    s += "  $ timescaledb_move.sh\n\n"
-    s += "This will install the extension files in the proper place. \n"
-    s += "If installed via Homebrew:\n\n"
-    s += "  $ brew services restart postgresql\n\n"
+    s += "  timescaledb_move.sh\n\n"
+
+    s += "If PostgreSQL is installed via Homebrew, restart it:\n\n"
+    s += "  brew services restart postgresql\n\n"
     s
   end
 end


### PR DESCRIPTION
This package can be installed separately or as part of the regular
TimescaleDB installation. It is a recommended dependency so it
will be installed unless the user passes a --without-timescaledb-tools
flag to the brew install.