### PR TITLE
Change timescaledb formula to use Postgres 11

### DIFF
--- a/timescaledb.rb
+++ b/timescaledb.rb
@@ -6,7 +6,7 @@ class Timescaledb < Formula
   sha256 "48fa9496ac511f00b019d88878a5301ed9bc9be351104a672a80d5a56b351a0b"
 
   depends_on "cmake" => :build
-  depends_on "postgresql" => :build
+  depends_on "postgresql@11" => :build
   depends_on "openssl" => :build
   depends_on "xz" => :build
   depends_on "timescaledb-tools" => :recommended


### PR DESCRIPTION
As per issue #10, the timescaledb formula fails to build after PostgreSQL 12 became the default version in Homebrew. This is just the changes that were suggested as a workaround.

(Using the formula as part of a fully automated setup, so I didn't want to have a required manual process - will use this PR for the time being)