### PR TITLE
Change default postgres version to 12

### DIFF
--- a/timescaledb.rb
+++ b/timescaledb.rb
@@ -6,7 +6,7 @@ class Timescaledb < Formula
   sha256 "d7ea99d19d4928c8bcd95301c71554726346f82c440e14bb8a067b2474397442"
 
   depends_on "cmake" => :build
-  depends_on "postgresql" => :build
+  depends_on "postgresql@12" => :build
   depends_on "openssl" => :build
   depends_on "xz" => :build
   depends_on "timescaledb-tools" => :recommended


### PR DESCRIPTION
As installing default postgres version 13 isn't supported yet. Adding an explicit postgres version

Fixes: #13 
Signed-off-by: Vineeth Pothulapati <vineethpothulapati@outlook.com>