### PR TITLE
Release Toolkit 1.12.0

### DIFF
--- a/timescaledb-toolkit.rb
+++ b/timescaledb-toolkit.rb
@@ -35,7 +35,9 @@ class TimescaledbToolkit < Formula
       system "cargo", "pgx", "package"
     end
 
-    (lib/postgresql.name).install Dir["target/release/**/lib/**/timescaledb_toolkit.so"]
+    system "cargo", "run", "--bin", "post-install", "--", "--dir", "target/release/timescaledb_toolkit-pg14"
+
+    (lib/postgresql.name).install Dir["target/release/**/lib/**/timescaledb_toolkit*.so"]
     (share/postgresql.name/"extension").install Dir["target/release/**/share/**/timescaledb_toolkit--*.sql"]
     (share/postgresql.name/"extension").install Dir["target/release/**/share/**/timescaledb_toolkit.control"]
   end
@@ -48,7 +50,7 @@ class TimescaledbToolkit < Formula
     system pg_ctl, "initdb", "-D", testpath/"test"
     (testpath/"test/postgresql.conf").write <<~EOS, mode: "a+"
 
-      shared_preload_libraries = 'timescaledb_toolkit'
+      shared_preload_libraries = 'timescaledb_toolkit-#{version}'
       port = #{port}
     EOS
     system pg_ctl, "start", "-D", testpath/"test", "-l", testpath/"log"

--- a/timescaledb-toolkit.rb
+++ b/timescaledb-toolkit.rb
@@ -7,7 +7,7 @@ class TimescaledbToolkit < Formula
 
   bottle do
     root_url "https://github.com/timescale/timescaledb-toolkit/releases/download/1.11.0"
-    sha256 cellar: :any, arm64_monterey: "047c1923c137674572b391dd7fd6d2f0a1f501cbf34d04fa29ee9b6783df2f2c"
+    sha256 cellar: :any, arm64_monterey: "b170f821963811ebbf03fa473b50d6468bf87bccd3ea5b9e29dba71524d9c981"
   end
 
   depends_on "rust" => :build

--- a/timescaledb-toolkit.rb
+++ b/timescaledb-toolkit.rb
@@ -1,13 +1,13 @@
 class TimescaledbToolkit < Formula
   desc "Extension for more hyperfunctions, fully compatible with TimescaleDB and PostgreSQL"
   homepage "https://www.timescale.com"
-  url "https://github.com/timescale/timescaledb-toolkit/archive/refs/tags/1.11.0.tar.gz"
-  sha256 "965766c9360a6a1f3be9960e9233ccfaa3f1b555d0a2e1928dc5914b348e2416"
+  url "https://github.com/timescale/timescaledb-toolkit/archive/refs/tags/1.12.0.tar.gz"
+  sha256 "a4fe2079880d6ab7b26f9a38510fd099beae81288e40e928622738bc0d9ded58"
   head "https://github.com/timescale/timescaledb-toolkit.git", branch: "main"
 
   bottle do
     root_url "https://github.com/timescale/timescaledb-toolkit/releases/download/1.11.0"
-    sha256 cellar: :any, arm64_monterey: "b6a587176b3c6e353fc3c852813b3c09da2153b644f42422f4ce5648266b25c7"
+    sha256 cellar: :any, arm64_monterey: "047c1923c137674572b391dd7fd6d2f0a1f501cbf34d04fa29ee9b6783df2f2c"
   end
 
   depends_on "rust" => :build
@@ -19,8 +19,8 @@ class TimescaledbToolkit < Formula
   end
 
   resource "cargo-pgx" do
-    url "https://github.com/tcdi/pgx/archive/refs/tags/v0.4.5.tar.gz"
-    sha256 "dad315b56495c7a35efa941a71494b71a6d9eb3549900534ed5fc0ba88dcb0fe"
+    url "https://github.com/tcdi/pgx/archive/refs/tags/v0.5.4.tar.gz"
+    sha256 "7c6b5e7fdc6b974b726bb4b965ae8e9dacecc059db1a59b1ec471edb090b4454"
   end
 
   def install

--- a/timescaledb-toolkit.rb
+++ b/timescaledb-toolkit.rb
@@ -8,6 +8,7 @@ class TimescaledbToolkit < Formula
   bottle do
     root_url "https://github.com/timescale/timescaledb-toolkit/releases/download/1.11.0"
     sha256 cellar: :any, arm64_monterey: "b170f821963811ebbf03fa473b50d6468bf87bccd3ea5b9e29dba71524d9c981"
+    sha256 cellar: :any, arm64_ventura: "7360783972362f1ee9343ca20d5b8a11b1d7a4bc53f69e29a45431dd5e57fa96"
   end
 
   depends_on "rust" => :build


### PR DESCRIPTION
[Toolkit 1.12.0](https://github.com/timescale/timescaledb-toolkit/releases/tag/1.12.0) has been released 