### PR TITLE
Adjust library extension for PG16

### DIFF
--- a/timescaledb.rb
+++ b/timescaledb.rb
@@ -31,7 +31,7 @@ class Timescaledb < Formula
     `chmod +x timescaledb_move.sh`
     `echo "#!/bin/bash" >> timescaledb_move.sh`
     `echo "echo 'Moving files into place...'" >> timescaledb_move.sh`
-    `echo "/usr/bin/install -c -m 755 \\\$(find #{lib} -name timescaledb*.so) #{libdir.strip}/" >> timescaledb_move.sh`
+    `echo "/usr/bin/install -c -m 755 \\\$(find #{lib} -name timescaledb*.dylib) #{libdir.strip}/" >> timescaledb_move.sh`
     `echo "/usr/bin/install -c -m 644 #{share}/timescaledb/* #{sharedir.strip}/extension/" >> timescaledb_move.sh`
     `echo "echo 'Success.'" >> timescaledb_move.sh`
     bin.install "timescaledb_move.sh"


### PR DESCRIPTION
Since 3727aa74772017bd40e58acad2a0a512b8814eb8 we use PG16 for homebrew builds. However, since PG 16 the extension of the library has changed to .dylib. This patch adjusts the installation scripts.