### PR TITLE
Update postgresql dependency from pg16 to pg17

### DIFF
--- a/timescaledb-toolkit.rb
+++ b/timescaledb-toolkit.rb
@@ -30,6 +30,11 @@ class TimescaledbToolkit < Formula
       system "cargo", "pgrx", "package"
     end
 
+    dylib = Dir.glob("target/release/timescaledb_toolkit-pg17/**/timescaledb_toolkit*.dylib").first
+    if dylib
+      File.rename(dylib, dylib.sub(/\.dylib$/, '.so'))
+    end
+
     system "cargo", "run", "--bin", "post-install", "--", "--dir", "target/release/timescaledb_toolkit-pg17"
 
     (lib/postgresql.name).install Dir["target/release/**/lib/**/timescaledb_toolkit*.so"]

--- a/timescaledb-toolkit.rb
+++ b/timescaledb-toolkit.rb
@@ -1,21 +1,21 @@
 class TimescaledbToolkit < Formula
   desc "Extension for more hyperfunctions, fully compatible with TimescaleDB and PostgreSQL"
   homepage "https://www.timescale.com"
-  url "https://github.com/timescale/timescaledb-toolkit/archive/refs/tags/1.17.0.tar.gz"
-  sha256 "268d238359316e439f93eb5a433baf8482be49ed168c20e24bba61b19dc5563f"
+  url "https://github.com/timescale/timescaledb-toolkit/archive/refs/tags/1.19.0.tar.gz"
+  sha256 "b7d58e1b1ed7c5b66409991133e4e361f723cf446cbea7dd9f894ec11ddd6652"
   head "https://github.com/timescale/timescaledb-toolkit.git", branch: "main"
 
   depends_on "rust" => :build
   depends_on "rustfmt" => :build
-  depends_on "postgresql@15"
+  depends_on "postgresql@17"
 
   def postgresql
-    Formula["postgresql@15"]
+    Formula["postgresql@17"]
   end
 
   resource "cargo-pgrx" do
-    url "https://github.com/pgcentralfoundation/pgrx/archive/refs/tags/v0.9.7.tar.gz"
-    sha256 "26580e7d844ebcc26f449a463babc65d63341da10c9a0c92565bd35749ba7733"
+    url "https://github.com/pgcentralfoundation/pgrx/archive/refs/tags/v0.12.8.tar.gz"
+    sha256 "bfdbeb96c777a15daa9cba0308d75ef49e23a8b30f4d3040ddde528d6ef337f8"
   end
 
   def install
@@ -24,13 +24,13 @@ class TimescaledbToolkit < Formula
 
     resource("cargo-pgrx").stage "pgrx"
     system "cargo", "install", "--locked", "--path", "pgrx/cargo-pgrx"
-    system "cargo", "pgrx", "init", "--pg15", "pg_config"
+    system "cargo", "pgrx", "init", "--pg17", "pg_config"
 
     cd "extension" do
       system "cargo", "pgrx", "package"
     end
 
-    system "cargo", "run", "--bin", "post-install", "--", "--dir", "target/release/timescaledb_toolkit-pg15"
+    system "cargo", "run", "--bin", "post-install", "--", "--dir", "target/release/timescaledb_toolkit-pg17"
 
     (lib/postgresql.name).install Dir["target/release/**/lib/**/timescaledb_toolkit*.so"]
     (share/postgresql.name/"extension").install Dir["target/release/**/share/**/timescaledb_toolkit--*.sql"]

--- a/timescaledb.rb
+++ b/timescaledb.rb
@@ -41,7 +41,7 @@ class Timescaledb < Formula
   end
 
   def check_postgresql_version
-    if postgresql.version >= Version.new('17.0') && postgresql.revision == 1
+    if postgresql.version >= Version.new('17.0') && postgresql.revision < 2
       odie "PostgreSQL 17.02 or higher is required, but you have #{postgresql.version}.#{postgresql.revision}"
     end
   end

--- a/timescaledb.rb
+++ b/timescaledb.rb
@@ -41,8 +41,8 @@ class Timescaledb < Formula
   end
 
   def check_postgresql_version
-    if postgresql.version >= Version.new('17.0') && postgresql.revision < 3
-      odie "PostgreSQL 17.03 or higher is required, but you have #{postgresql.version}.#{postgresql.revision}"
+    if postgresql.version >= Version.new('17.0') && postgresql.revision == 1
+      odie "PostgreSQL 17.02 or higher is required, but you have #{postgresql.version}.#{postgresql.revision}"
     end
   end
 

--- a/timescaledb.rb
+++ b/timescaledb.rb
@@ -10,12 +10,12 @@ class Timescaledb < Formula
 
   depends_on "cmake" => :build
   depends_on "openssl" => :build
-  depends_on "postgresql@16" => :build
+  depends_on "postgresql@17" => :build
   depends_on "xz" => :build
   depends_on "timescale/tap/timescaledb-tools" => :recommended
 
   def postgresql
-    Formula["postgresql@16"]
+    Formula["postgresql@17"]
   end
 
   def install

--- a/timescaledb.rb
+++ b/timescaledb.rb
@@ -19,6 +19,7 @@ class Timescaledb < Formula
   end
 
   def install
+    check_postgresql_version
     ossvar = build.with?("oss-only") ? " -DAPACHE_ONLY=1" : ""
     ssldir = Formula["openssl"].opt_prefix
 
@@ -37,6 +38,12 @@ class Timescaledb < Formula
     bin.install "timescaledb_move.sh"
     (lib/"timescaledb").install Dir["stage/**/lib/*"]
     (share/"timescaledb").install Dir["stage/**/share/postgresql*/extension/*"]
+  end
+
+  def check_postgresql_version
+    if postgresql.version >= Version.new('17.0') && postgresql.revision < 3
+      odie "PostgreSQL 17.03 or higher is required, but you have #{postgresql.version}.#{postgresql.revision}"
+    end
   end
 
   def caveats


### PR DESCRIPTION
Let's user on Mac have the experience to work with latest postgresql and latest timescaledb.

It may not be ideal for those already running the previous versions but as we're compatible, we should encourage folks to run on latest in dev machines.

Also, related to https://www.timescale.com/forum/t/homebrew-timescaledb-installs-new-pg16-already-have-pg17/2876/3

How to test:

```
brew unlink postgresql@16
brew install postgresql@17 -- or leave it as a dependency
cd /usr/local/Homebrew/Library/Taps/timescale/homebrew-tap
git checkout pg17
brew reinstall --build-from-source timescale/tap/timescaledb
brew reinstall --build-from-source timescale/tap/timescaledb-toolkit
```

