### PR TITLE
 Fix postgresql version check

### DIFF
--- a/timescaledb.rb
+++ b/timescaledb.rb
@@ -41,7 +41,7 @@ class Timescaledb < Formula
   end
 
   def check_postgresql_version
-    if postgresql.version >= Version.new('17.0') && postgresql.revision < 2
+    if postgresql.version <  Version.new('17.2')
       odie "PostgreSQL 17.02 or higher is required, but you have #{postgresql.version}.#{postgresql.revision}"
     end
   end


### PR DESCRIPTION
Fix https://github.com/timescale/homebrew-tap/issues/51 The postgresql formula returns the version like this: postgresql.version = 17.2
postgresql.revision = 0