### PR TITLE
Version between 17.0 and 17.1

### DIFF
--- a/timescaledb.rb
+++ b/timescaledb.rb
@@ -41,7 +41,8 @@ class Timescaledb < Formula
   end
 
   def check_postgresql_version
-    if postgresql.version >= Version.new('17.0') && postgresql.revision < 2
+    if postgresql.version >= Version.new('17.0') &&
+        postgresql.version <= Version.new('17.1') && postgresql.revision < 2
       odie "PostgreSQL 17.02 or higher is required, but you have #{postgresql.version}.#{postgresql.revision}"
     end
   end


### PR DESCRIPTION
It seems like new Postgresql versions are getting caught by this logic. We need to validate between 17.01 and 17.02, but not more than that. Now, with PostgreSQL on 17.2, it's still complaining of an invalid version.

## How to test it

```
cd /opt/homebrew/Library/Taps/timescale/homebrew-tap/
git fetch origin
git checkout fix-version-validation
brew reinstall --build-from-source timescale/tap/timescaledb
```




